### PR TITLE
Fix explorer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,11 +75,7 @@
                 {
                   imports = [
                     "${inputs.nixpkgs}/nixos/modules/virtualisation/amazon-image.nix"
-                    (import ./nix/hydra-explorer-configuration.nix {
-                      cardano-node-module = inputs.cardano-node.nixosModules.cardano-node;
-                      hydra-explorer = inputs.self.packages.x86_64-linux.hydra-explorer;
-                      hydra-explorer-web = inputs.self.packages.x86_64-linux.hydra-explorer-web;
-                    })
+                    (import ./nix/hydra-explorer-configuration.nix)
                   ];
                 }
                 inputs.agenix.nixosModules.default

--- a/nix/hydra-explorer-configuration.nix
+++ b/nix/hydra-explorer-configuration.nix
@@ -9,7 +9,7 @@
   };
 
   nix = {
-    settings.trusted-users = [ "root" "runner" ];
+    settings.trusted-users = [ "root" ];
     extraOptions = ''
       experimental-features = nix-command flakes recursive-nix ca-derivations
       log-lines = 300
@@ -33,20 +33,16 @@
   services.getty.autologinUser = "root";
 
   # Github runner registered with cardano-scaling organization
-  users.users.runner = {
-    isNormalUser = true;
-    uid = 1001;
-    group = "users";
-    extraGroups = [ ];
-  };
   age.secrets.github-runner-token.file = ../secrets/github-runner-token.age;
+
+  # TODO: Run this with 'runner' user? If yes, then we need to fix permissions
+  # on the /data paths and/or make the containers rootless (run by 'runner')?
   services.github-runners.explorer = {
     enable = true;
     url = "https://github.com/cardano-scaling";
     tokenFile = "/run/agenix/github-runner-token";
     replace = true;
     extraLabels = [ "nixos" "self-hosted" "explorer" "cardano" ];
-    user = "runner";
     serviceOverrides = {
       # See: https://discourse.nixos.org/t/github-runners-cp-read-only-filesystem/36513/2
       ReadWritePaths = [

--- a/nix/hydra-explorer-configuration.nix
+++ b/nix/hydra-explorer-configuration.nix
@@ -51,6 +51,10 @@
     };
   };
 
+  # Use podman to manage containers
+  virtualisation.podman.enable = true;
+  virtualisation.podman.dockerCompat = true;
+
   # Cardano node used by Hydra smoke tests and explorer instance
   # TODO: initialize /data/cardano/preview correctly on a fresh machine
   virtualisation.oci-containers.containers.cardano-node-preview = {


### PR DESCRIPTION
Re-enable hosting of http://explorer.hydra.family/ by recreating the `explorer/docker-compose.yaml` from before into the NixOS configuration.

That is, a single version (`0.19.0`) explorer running on one network (`preview`).

This is only a temporary way of deploying, until a continuous deployment has been achieved with #1 