### PR TITLE
Restart observers when explorer restarts

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always
@@ -51,6 +55,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always
@@ -68,6 +76,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always
@@ -87,6 +99,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always
@@ -104,6 +120,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always
@@ -121,6 +141,10 @@ services:
       # NOTE: Reachable via hydra-explorer network
       , "--explorer", "http://hydra-explorer:8001"
       ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
     networks:
       - hydra-explorer
     restart: always


### PR DESCRIPTION
This is important as the continuous deployment may only deploy the explorer container and observers don't crash/restart automatically (if deployed too quickly).