### PR TITLE
Deploy 0.19.1 chain observers

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -65,6 +65,10 @@ jobs:
         [[ ${BUILDING_TAG} = true ]] && \
           VERSION_NAME=${{github.ref_name}}
 
+        BUILDING_ON_MASTER=false
+        [[ git merge-base --is-ancestor HEAD origin/master ]] && \
+          BUILDING_ON_MASTER=true
+
         # Use 'FROM' instruction to use docker build with --label
         echo "FROM hydra-explorer" | docker build \
           --label org.opencontainers.image.source=${{github.repositoryUrl}} \
@@ -74,17 +78,18 @@ jobs:
           --label org.opencontainers.image.version=${VERSION_NAME:-unstable} \
           --tag ${IMAGE_NAME}:unstable -
 
-        # Also tag with semver and 'latest' if we are building a tag
-        [[ ${BUILDING_TAG} = true ]] && \
-          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${{github.ref_name}}
-        [[ ${BUILDING_TAG} = true ]] && \
+        # Also tag with 'latest' if we are building on master
+        [[ ${BUIDING_TAG} && ${BUILDING_ON_MASTER} = true ]] && \
           docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:latest
-        # Tag image with workflow dispatch ref_name
+        # Also tag with version if we are building a tag
+        [[ ${BUILDING_TAG} = true && ${{matrix.target}} != "hydraw" ]] && \
+          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${VERSION_NAME}
+        # Also tag with ref name when manually dispatched
         [[ ${{github.event_name == 'workflow_dispatch'}} = true ]] && \
-          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:${{github.event.inputs.ref_name}}
+          docker tag ${IMAGE_NAME}:unstable ${IMAGE_NAME}:workflow_dispatch-${{github.event.inputs.ref_name}}
 
-        docker images
         docker inspect ${IMAGE_NAME}:unstable
+        docker images
 
     - name: 📤 Push to registry
       run: |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,8 +87,7 @@ services:
   ## 0.19
 
   hydra-chain-observer-preview-0.19:
-    # TODO: cut release 0.19.1
-    image: ghcr.io/cardano-scaling/hydra-chain-observer@sha256:5eae5f5e7e26f2af1428f0f90f43c54f2f12fcd9fb92a8bfdb96b7cefdb9233e
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.19.1
     volumes:
       - "/data/cardano/preview:/data"
     command:
@@ -108,8 +107,7 @@ services:
     restart: always
 
   hydra-chain-observer-preprod-0.19:
-    # TODO: cut release 0.19.1
-    image: ghcr.io/cardano-scaling/hydra-chain-observer@sha256:5eae5f5e7e26f2af1428f0f90f43c54f2f12fcd9fb92a8bfdb96b7cefdb9233e
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.19.1
     volumes:
       - "/data/cardano/preprod:/data"
     command:
@@ -129,8 +127,7 @@ services:
     restart: always
 
   hydra-chain-observer-mainnet-0.19:
-    # TODO: cut release 0.19.1
-    image: ghcr.io/cardano-scaling/hydra-chain-observer@sha256:5eae5f5e7e26f2af1428f0f90f43c54f2f12fcd9fb92a8bfdb96b7cefdb9233e
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.19.1
     volumes:
       - "/data/cardano/mainnet:/data"
     command:


### PR DESCRIPTION
This also includes the same changes to the `docker` workflow as in https://github.com/cardano-scaling/hydra/pull/1869