### PR TITLE
Observe the 0.21.0 release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,74 @@ services:
 
   # List of hydra-chain-observers
 
+  ## 0.21
+
+  hydra-chain-observer-preview-0.21:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.21.0
+    volumes:
+      - "/data/cardano/preview:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--testnet-magic", "2"
+      # NOTE: Block in which 0.21.0 scripts were published
+      , "--start-chain-from", "79181007.89c0e835770246ced1eaf8f4477a2600073ad0ec1ceea62505d9665528a00b13"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
+  hydra-chain-observer-preprod-0.21:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.21.0
+    volumes:
+      - "/data/cardano/preprod:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--testnet-magic", "1"
+      # NOTE: Block in which 0.21.0 scripts were published
+      , "--start-chain-from", "90154257.95d0da1ddd4ba70b2b29f364beae7d2cb35365fdf8df8c5e19a27b52dd8f0f10"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
+  hydra-chain-observer-mainnet-0.21:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.21.0
+    volumes:
+      - "/data/cardano/mainnet:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--mainnet"
+      # NOTE: Block in which 0.21.0 scripts were published
+      , "--start-chain-from", "154271531.7368a0e9b54943547b40f989d920fba4a0a347475e90ea0118924ecb4e357d3d"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
   ## 0.20
 
   hydra-chain-observer-preview-0.20:


### PR DESCRIPTION
You can verify the blocks like so:

- [mainnet script](https://cexplorer.io/tx/b5d5fa4d367005bdd6449dcca049aa61aa8b59a907231b03bb006eda01e8e73a)
- [preprod](https://preprod.cexplorer.io/tx/557b6a6eaf6177407757cb82980ebc5b759b150ccfd329e1d8f81bbd16fecb01)
- [preview](https://preview.cexplorer.io/tx/bdf8a262cd5e7c8f4961aed865c026d5b6314b22a4bc31e981363b5bb50d1da6)

Fixes https://github.com/cardano-scaling/hydra-explorer/issues/45