### PR TITLE
Enable strict data on explorer state

### DIFF
--- a/hydra-explorer/src/Hydra/Explorer/ExplorerState.hs
+++ b/hydra-explorer/src/Hydra/Explorer/ExplorerState.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE StrictData #-}
+
 module Hydra.Explorer.ExplorerState where
 
 import Hydra.Prelude


### PR DESCRIPTION
We might have a memory leak that shows when running in production. Let's see if this fixes it?