### PR TITLE
Observe the 0.22.0 release

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,74 @@ services:
 
   # List of hydra-chain-observers
 
+  ## 0.22
+
+  hydra-chain-observer-preview-0.22:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.22.0
+    volumes:
+      - "/data/cardano/preview:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--testnet-magic", "2"
+      # NOTE: Block in which 0.22.0 scripts were published
+      , "--start-chain-from", "83494816.03d86af365c9ff1638aeacb891343c26a3c50066b6319b5c5ac0ed77d633a9c6"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
+  hydra-chain-observer-preprod-0.22:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.22.0
+    volumes:
+      - "/data/cardano/preprod:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--testnet-magic", "1"
+      # NOTE: Block in which 0.22.0 scripts were published
+      , "--start-chain-from", "94474101.da5a870f317943ea8e92b070875b9fb806659b6df3a2871a6addf8f9b8fdd2ea"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
+  hydra-chain-observer-mainnet-0.22:
+    image: ghcr.io/cardano-scaling/hydra-chain-observer:0.22.0
+    volumes:
+      - "/data/cardano/mainnet:/data"
+    command:
+      [ "--node-socket", "/data/node.socket"
+      , "--mainnet"
+      # NOTE: Block in which 0.22.0 scripts were published
+      , "--start-chain-from", "158590430.97a33745faba570583613f5bf994ff7fbe0933933ac2ad0e635173102a84a962"
+      # NOTE: Reachable via hydra-explorer network
+      , "--explorer", "http://hydra-explorer:8001"
+      ]
+    depends_on:
+      hydra-explorer:
+        condition: service_started
+        restart: true
+    networks:
+      - hydra-explorer
+    restart: always
+    logging:
+      driver: journald
+
   ## 0.21
 
   hydra-chain-observer-preview-0.21:


### PR DESCRIPTION
You can verify the blocks like so:

[mainnet script](https://cexplorer.io/tx/0571111c9cdbc4880625fb70c88eb2de1e09752a7b5a984644f7be6a0037051f)
[preprod](https://preprod.cexplorer.io/tx/c9c4d820d5575173cfa81ba2d2d1096fc40f84d16d8c17284da410a4fb5e64eb)
[preview](https://preview.cexplorer.io/tx/f0836329dcc837ebc770de707a7490c90b5185d2f67a25b0ddbf19dc2b3efffb)
Fixes https://github.com/cardano-scaling/hydra-explorer/issues/51